### PR TITLE
Concatenate the registry ip on the /etc/hosts file

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -22,7 +22,7 @@ RABBITMQ_PASSWORD_PATH=/opt/runnable/rabbitmq_password
 DOCKER_LISTENER_CONF=/etc/init/docker-listener.conf
 SAURON_CONF=/etc/init/sauron.conf
 
-REGISTRY_IP_PATH=/opt/runnable/registry_ip
+REGISTRY_HOST_PATH=/opt/runnable/registry_host
 
 # Replaces an env directive in the given upstart configuration
 # $1 - Path to the upstart configuration
@@ -76,9 +76,9 @@ do
 done
 
 # Set correct registry.runnable.com host
-registry_ip=`cat $REGISTRY_IP_PATH`
-echo `date` "[INFO] Writing registry host: $registry_ip"
-echo "$registry_ip registry.runnable.com" >> /etc/hosts
+registry_host=`cat $REGISTRY_HOST_PATH`
+echo `date` "[INFO] Set registry host: $registry_host" >> $DOCK_INIT_LOG_PATH
+echo "$registry_host registry.runnable.com" >> /etc/hosts
 
 # Restart docker
 service docker restart


### PR DESCRIPTION
Sets the registry.runnable ip in the /etc/hosts on the dock machine during initialization.
