### PR TITLE
start datadog on upstart

### DIFF
--- a/lib/upstart.sh
+++ b/lib/upstart.sh
@@ -131,7 +131,7 @@ upstart::start_docker() {
 
 # Upstarts services that are supposed to be running on the dock.
 # @param $1 attempt Attempt number.
-upstart::upstart_services() {
+upstart::upstart_services_with_backoff_params() {
   local attempt="${1}"
   upstart::upstart_named_service "filibuster" $attempt
   upstart::upstart_named_service "krain" $attempt
@@ -180,7 +180,7 @@ upstart::start() {
   upstart::generate_scripts
   upstart::start_docker
   backoff upstart::pull_image_builder
-  backoff upstart::upstart_services
+  backoff upstart::upstart_services_with_backoff_params
   upstart::start_swarm_container
 }
 

--- a/test/upstart.sh
+++ b/test/upstart.sh
@@ -50,7 +50,7 @@ describe 'upstart.sh'
     end
   end
 
-  describe 'upstart::upstart_services'
+  describe 'upstart::upstart_services_with_backoff_params'
     it 'should start all our services'
       local storage=""
       serviceStub() { storage+="$@ "; }
@@ -58,7 +58,7 @@ describe 'upstart.sh'
       stub::set upstart::upstart_service serviceStub
 
       local attempt=8
-      upstart::upstart_services $attempt
+      upstart::upstart_services_with_backoff_params $attempt
 
       assert equal "filibuster 8 krain 8 charon 8 docker-listener 8 datadog-agent 8 " "$storage"
 


### PR DESCRIPTION
looks like it was dropped during the refactor. adding it back in, with tests.
- [x] @anandkumarpatel
- [x] @rsandor
