### PR TITLE
Fixed the host and port for charon's datadog.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -14,9 +14,6 @@ export CONSUL_HOSTNAME
 export HOST_IP=$(hostname -i)
 export environment=""
 
-# For node-gyp, requires home to be defined when doing an NPM install
-export HOME=/home/ubuntu
-
 if [ -z "${CONSUL_PORT+x}" ]; then
   export CONSUL_PORT=8500
 else

--- a/lib/upstart.sh
+++ b/lib/upstart.sh
@@ -79,7 +79,7 @@ upstart::upstart_named_service() {
   cd "/opt/runnable/$name" &&
   ssh-agent bash -c "ssh-add $key_path; git fetch origin" &&
   git checkout "$version" &&
-  ssh-agent bash -c "ssh-add $key_path; npm install --production" &&
+  ssh-agent bash -c "ssh-add $key_path; USERPROFILE=/home/ubuntu npm install --production" &&
   service "$name" restart
 
   rollbar::clear_trap


### PR DESCRIPTION
Charon was pointing to API's datadog host for reporting, which was rejecting messages. It should be pointing to localhost. After this is merged and deployed out to new docks we should start to see timing metrics again.

Reviewers:
- [ ] @anandkumarpatel 
