### PR TITLE
SAN-3286; Backoff for Image Builder Pull

### DIFF
--- a/lib/consul.sh
+++ b/lib/consul.sh
@@ -8,7 +8,7 @@ source "${DOCK_INIT_BASE}/lib/vault.sh"
 # @author Ryan Sandor Richards
 # @module consul
 
-# Backoff andler for ensuring the dock can connect to consul
+# Backoff handler for ensuring the dock can connect to consul
 # @param $1 attempt The attempt number passed by the backoff routine below
 consul::connect_backoff() {
   local attempt=${1}

--- a/lib/upstart.sh
+++ b/lib/upstart.sh
@@ -140,9 +140,9 @@ upstart::upstart_services_with_backoff_params() {
   upstart::upstart_service "datadog-agent" $attempt
 }
 
-# Pulls the latest docker image for the runnable image builder
+# Backoff handler for pulling the latest image builder
 # @param $1 attempt The current attempt for pulling image builder
-upstart::pull_image_builder() {
+upstart::pull_image_builder_backoff() {
   local attempt="${1}"
   local name="image-builder"
   local version
@@ -153,7 +153,7 @@ upstart::pull_image_builder() {
     "Dock-Init: Cannot Upstart Services" \
     "Attempting to upstart the services and failing." \
     "${data}"
-  backoff docker pull "registry.runnable.com/runnable/image-builder:$version"
+  docker pull "registry.runnable.com/runnable/image-builder:$version"
   rollbar::clear_trap
 }
 
@@ -180,7 +180,7 @@ upstart::start() {
   log::info "Upstarting dock"
   upstart::generate_scripts
   upstart::start_docker
-  backoff upstart::pull_image_builder
+  backoff upstart::pull_image_builder_backoff
   backoff upstart::upstart_services_with_backoff_params
   upstart::start_swarm_container
 }


### PR DESCRIPTION
EDIT: this is now owned by @rsandor
- [ ] Test by running on a dock and disabling/reenabling network connectivity

https://runnable.atlassian.net/browse/SAN-3286
