### PR TITLE
SAN-3469; Add Registry Host to Logs

### DIFF
--- a/lib/dock.sh
+++ b/lib/dock.sh
@@ -99,8 +99,9 @@ dock::generate_etc_hosts() {
 
 # Sets the correct registry.runnable.com host
 dock::set_registry_host() {
-  log::info "Set registry host"
-  cat "$DOCK_INIT_BASE"/hosts-registry.txt >> /etc/hosts
+  local registry_host=$(cat "$DOCK_INIT_BASE/hosts-registry.txt")
+  log::info "Set registry host: $registry_host"
+  echo "$registry_host" >> /etc/hosts
 }
 
 # Remove docker key file so it generates a unique id


### PR DESCRIPTION
This simply `echo`s the registry host that is being appended to the `/etc/hosts` file. This should help us debug issues similar to [SAN-3469](https://runnable.atlassian.net/browse/SAN-3469) in the future.
- [x] Tested in staging

**Reviewers:**
- [x] @bkendall 
