### PR TITLE
Charon Log Level

### DIFF
--- a/consul-resources/templates/services/charon.conf.ctmpl
+++ b/consul-resources/templates/services/charon.conf.ctmpl
@@ -23,7 +23,7 @@ env API_URL={{ key "api/url" }}
 env DATADOG_HOST=localhost
 env DATADOG_PORT=8125
 
-env LOG_LEVEL=warning
+env LOG_LEVEL=warn
 
 start on (local-filesystems and net-device-up IFACE=eth0)
 stop on shutdown


### PR DESCRIPTION
Let's set Charon log level to `warning` for now. We need to cut back on our loggly sending, and this is the quick way to do it.
