### PR TITLE
dock-init vault: use aws_1h mount

### DIFF
--- a/consul-resources/templates/get-org-tag.sh.ctmpl
+++ b/consul-resources/templates/get-org-tag.sh.ctmpl
@@ -3,7 +3,7 @@ set -e
 
 # WARNING: do not echo anything except ORG ID here
 
-{{ with vault "aws/creds/dock-init" }}
+{{ with vault "aws_1h/creds/dock-init" }}
 AWS_ACCESS_KEY="{{ .Data.access_key }}"
 AWS_SECRET_KEY="{{ .Data.secret_key  }}"
 {{ end }}


### PR DESCRIPTION
use the `aws_1h` mount point of vault so the credentials will only be around for 1 hour!
#### Reviewers
- [x] @anandkumarpatel 
#### Dependencies
- [x] https://github.com/CodeNow/devops-scripts/pull/484
